### PR TITLE
[RemoveDIs][NFC] Add DbgLabelRecord class [3/4]

### DIFF
--- a/llvm/include/llvm/IR/DebugProgramInstruction.h
+++ b/llvm/include/llvm/IR/DebugProgramInstruction.h
@@ -82,7 +82,7 @@ public:
   /// Marker that this DbgRecord is linked into.
   DbgMarker *Marker = nullptr;
   /// Subclass discriminator.
-  enum Kind : uint8_t { ValueKind };
+  enum Kind : uint8_t { ValueKind, LabelKind };
 
 protected:
   DebugLoc DbgLoc;
@@ -139,6 +139,30 @@ protected:
   /// cleanup.
   /// Use deleteRecord to delete a generic record.
   ~DbgRecord() = default;
+};
+
+/// Records a position in IR for a source label (DILabel). Corresponds to the
+/// llvm.dbg.label intrinsic.
+class DbgLabelRecord : public DbgRecord {
+  DILabel *Label;
+
+public:
+  DbgLabelRecord(DILabel *Label, DebugLoc DL)
+      : DbgRecord(LabelKind, DL), Label(Label) {
+    assert(Label && "unexpected nullptr");
+  }
+
+  DbgLabelRecord *clone() const;
+  void print(raw_ostream &O, bool IsForDebug = false) const;
+  void print(raw_ostream &ROS, ModuleSlotTracker &MST, bool IsForDebug) const;
+
+  void setLabel(DILabel *NewLabel) { Label = NewLabel; }
+  DILabel *getLabel() const { return Label; }
+
+  /// Support type inquiry through isa, cast, and dyn_cast.
+  static bool classof(const DbgRecord *E) {
+    return E->getRecordKind() == LabelKind;
+  }
 };
 
 /// Record of a variable value-assignment, aka a non instruction representation

--- a/llvm/lib/IR/DebugProgramInstruction.cpp
+++ b/llvm/lib/IR/DebugProgramInstruction.cpp
@@ -46,6 +46,9 @@ void DbgRecord::deleteRecord() {
   case ValueKind:
     delete cast<DbgVariableRecord>(this);
     break;
+  case LabelKind:
+    delete cast<DbgLabelRecord>(this);
+    break;
   default:
     llvm_unreachable("unsupported record kind");
   }
@@ -54,6 +57,9 @@ void DbgRecord::print(raw_ostream &O, bool IsForDebug) const {
   switch (RecordKind) {
   case ValueKind:
     cast<DbgVariableRecord>(this)->print(O, IsForDebug);
+    break;
+  case LabelKind:
+    cast<DbgLabelRecord>(this)->print(O, IsForDebug);
     break;
   default:
     llvm_unreachable("unsupported record kind");
@@ -65,6 +71,9 @@ void DbgRecord::print(raw_ostream &O, ModuleSlotTracker &MST,
   switch (RecordKind) {
   case ValueKind:
     cast<DbgVariableRecord>(this)->print(O, MST, IsForDebug);
+    break;
+  case LabelKind:
+    cast<DbgLabelRecord>(this)->print(O, MST, IsForDebug);
     break;
   default:
     llvm_unreachable("unsupported record kind");
@@ -217,6 +226,8 @@ DbgRecord *DbgRecord::clone() const {
   switch (RecordKind) {
   case ValueKind:
     return cast<DbgVariableRecord>(this)->clone();
+  case LabelKind:
+    return cast<DbgLabelRecord>(this)->clone();
   default:
     llvm_unreachable("unsupported record kind");
   };


### PR DESCRIPTION
Patch 1 of 4 to add llvm.dbg.label support to the RemoveDIs project. The patch
stack adds a new base class, and takes this opportunity to rename the RemoveDIs
classes to something more meaningful.

       1. Add DbgRecord base class for DPValue and the not-yet-added
          DbgLabelRecord class.
       2. Rename DPValue -> DbgVariableRecord, DPMarker -> DbgMarker.
    -> 3. Add the DbgLabelRecord class.
       4. Enable dbg.label conversion and add support to passes.

Patches 1, 2, and 3 are NFC.

---

Add the DbgLabelRecord class.